### PR TITLE
Use no-omit-frame-pointer compiler flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CLD=sdldz80
 OBJCPY=sdobjcopy
 
 ASFLAGS=-plosgff
-CFLAGS=-mez80_z80 -Iinclude/ -Isrc/include/ --reserve-regs-iy --std-c11 --fomit-frame-pointer
+CFLAGS=-mez80_z80 -Iinclude/ -Isrc/include/ --reserve-regs-iy --std-c11 --fno-omit-frame-pointer
 CLINK=--no-std-crt0 -mez80_z80 --code-loc 100
 
 all: a.bin


### PR DESCRIPTION
Change compiler flag to `no-omit-frame-pointer`, otherwise sdcc generates incorrect code when accessing the function params from the stack.

Consider following code:
```
void gotoxy(unsigned int x, unsigned int y) {
    putchar(31);
    putchar(x);
    putchar(y);
}
```

With current compiler option it will be compiled to:
```
000000                         55 _gotoxy::
      000000 DD E5            [ 4]   56 	push	ix
      000002 DD 21 00 00      [ 4]   57 	ld	ix,#0
      000006 DD 39            [ 2]   58 	add	ix,sp
                                     59 ;src/main.c:6: putchar(31);
      000008 21 1F 00         [ 3]   60 	ld	hl, #0x001f
      00000B E5               [ 3]   61 	push	hl
      00000C CDr00r00         [ 5]   62 	call	_putchar
      00000F 33               [ 1]   63 	inc	sp
      000010 33               [ 1]   64 	inc	sp
                                     65 ;src/main.c:7: putchar(x);
      000011 DD 27 04         [ 5]   66 	ld	hl, 2 (ix)
      000014 E5               [ 3]   67 	push	hl
      000015 CDr00r00         [ 5]   68 	call	_putchar
      000018 33               [ 1]   69 	inc	sp
      000019 33               [ 1]   70 	inc	sp
                                     71 ;src/main.c:8: putchar(y);
      00001A DD 27 06         [ 5]   72 	ld	hl, 4 (ix)
      00001D E5               [ 3]   73 	push	hl
      00001E CDr00r00         [ 5]   74 	call	_putchar
      000021 33               [ 1]   75 	inc	sp
      000022 33               [ 1]   76 	inc	sp
                                     77 ;src/main.c:9: }
      000023 DD E1            [ 4]   78 	pop	ix
      000025 C9               [ 5]   79 	ret
```

This code is incorrect because the offset of the first argument should be `4 (ix)` (return address + pushed ix in the beginning). Changing compiler option to `no-omit-frame-pointer` fixes the issue.